### PR TITLE
Fix PythonToCppException caused by wrong parameter name

### DIFF
--- a/default.py
+++ b/default.py
@@ -26,7 +26,7 @@ addon_handle = int(sys.argv[1])
 xbmcplugin.setContent(addon_handle, 'movies')
 
 li = xbmcgui.ListItem('Frikanalen Nett-TV', iconImage='DefaultVideo.png')
-xbmcplugin.addDirectoryItem(handle=addon_handle, streamurl=streamurl, listitem=li)
+xbmcplugin.addDirectoryItem(handle=addon_handle, url=streamurl, listitem=li)
 
 xbmcplugin.endOfDirectory(addon_handle)
 


### PR DESCRIPTION
I am running OpenELEC (official) Version: 6.0.3, so not sure if this is breaking it for others, but from the [stable xbmcplugin](http://mirrors.xbmc.org/docs/python-docs/stable/xbmcplugin.html) this seems to be correct.
